### PR TITLE
Change to use ShareFile OAuth2 client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ composer.lock
 vendor
 phpunit.xml
 .phpunit-watcher.yml
+.buildpath
+.settings
+.project
+test.php

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 	"require-dev" : {
 		"larapack/dd" : "1.*",
 		"mikey179/vfsstream" : "^1.6",
-		"phpunit/phpunit" : "^8.0"
+		"phpunit/phpunit" : "^6.4"
 	},
 	"autoload" : {
 		"psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -1,51 +1,50 @@
 {
-    "name": "kapersoft/sharefile-api",
-    "description": "A minimal implementation of ShareFile Api",
-    "keywords": [
-        "kapersoft",
-        "sharefile-api",
-        "sharefile",
-        "api",
-        "php"
-    ],
-    "homepage": "https://github.com/kapersoft/sharefile-api",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "Jan Willem Kaper",
-            "email": "kapersoft@gmail.com",
-            "homepage": "https://kapersoft.com",
-            "role": "Developer"
-        }
-    ],
-    "require": {
-        "php": "^7.0",
-        "slacker775/oauth2-sharefile": "^1.0",
-        "guzzlehttp/guzzle": "^6.2",
-        "slacker775/oauth2-tokenstorage": "^1.0"
-    },
-    "require-dev": {
-        "larapack/dd": "1.*",
-        "mikey179/vfsstream": "^1.6",
-        "phpunit/phpunit": "^8.0"
-    },
-    "autoload": {
-        "psr-4": {
-            "Kapersoft\\Sharefile\\": "src/"
-        }
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Kapersoft\\Sharefile\\Test\\": "tests/"
-        }
-    },
-    "scripts": {
-        "test": "vendor/bin/phpunit"
-    },
-    "config": {
-        "sort-packages": true
-    },
-    "suggest": {
-        "league/flysystem": "Utilize Flysystem for OAuth Token Storage"
-    }
+	"name" : "kapersoft/sharefile-api",
+	"description" : "A minimal implementation of ShareFile Api",
+	"keywords" : [
+		"kapersoft",
+		"sharefile-api",
+		"sharefile",
+		"api",
+		"php"
+	],
+	"homepage" : "https://github.com/kapersoft/sharefile-api",
+	"license" : "MIT",
+	"authors" : [{
+			"name" : "Jan Willem Kaper",
+			"email" : "kapersoft@gmail.com",
+			"homepage" : "https://kapersoft.com",
+			"role" : "Developer"
+		}
+	],
+	"require" : {
+		"php" : "^7.0",
+		"slacker775/oauth2-sharefile" : "^1.0",
+		"guzzlehttp/guzzle" : "^6.2",
+		"slacker775/oauth2-tokenstorage" : "^1.0"
+	},
+	"require-dev" : {
+		"larapack/dd" : "1.*",
+		"mikey179/vfsstream" : "^1.6",
+		"phpunit/phpunit" : "^8.0"
+	},
+	"autoload" : {
+		"psr-4" : {
+			"Kapersoft\\ShareFile\\" : "src/"
+		}
+	},
+	"autoload-dev" : {
+		"psr-4" : {
+			"Kapersoft\\Sharefile\\Test\\" : "tests/"
+		}
+	},
+	"scripts" : {
+		"test" : "vendor/bin/phpunit"
+	},
+	"config" : {
+		"sort-packages" : true
+	},
+	"suggest" : {
+		"league/flysystem" : "Utilize Flysystem for OAuth Token Storage"
+	}
 }

--- a/composer.json
+++ b/composer.json
@@ -21,21 +21,22 @@
     "require": {
         "php": "^7.0",
         "slacker775/oauth2-sharefile": "^1.0",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^6.2",
+        "slacker775/oauth2-tokenstorage": "^1.0"
     },
     "require-dev": {
         "larapack/dd": "1.*",
-        "mikey179/vfsStream": "^1.6",
-        "phpunit/phpunit": "6.4.x-dev"
+        "mikey179/vfsstream": "^1.6",
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {
-            "Kapersoft\\Sharefile\\": "src"
+            "Kapersoft\\Sharefile\\": "src/"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Kapersoft\\Sharefile\\Test\\": "tests"
+            "Kapersoft\\Sharefile\\Test\\": "tests/"
         }
     },
     "scripts": {
@@ -43,5 +44,8 @@
     },
     "config": {
         "sort-packages": true
+    },
+    "suggest": {
+        "league/flysystem": "Utilize Flysystem for OAuth Token Storage"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
     ],
     "require": {
         "php": "^7.0",
+        "slacker775/oauth2-sharefile": "^1.0",
         "guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -8,7 +8,7 @@ use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Exception\ClientException;
-use Kapersoft\Sharefile\Exceptions\BadRequest;
+use Kapersoft\ShareFile\Exceptions\BadRequest;
 use Slacker775\OAuth2\Client\Provider\ShareFile as AuthProvider;
 use League\OAuth2\Client\Provider\AbstractProvider;
 use League\OAuth2\Client\Token\AccessToken;

--- a/src/Client.php
+++ b/src/Client.php
@@ -433,7 +433,7 @@ class Client
                 'index'      => $index,
                 'byteOffset' => $index * $chunkSize,
                 'hash'       => md5($data),
-                'filehash'   => Psr7\hash(Psr7\stream_for($stream), 'md5'),
+                'filehash'   => \GuzzleHttp\Psr7\hash(\GuzzleHttp\Psr7\stream_for($stream), 'md5'),
                 'finish'    => true,
             ]
         );
@@ -510,7 +510,7 @@ class Client
         }
     }
 
-    protected function getAccessToken(): AccessToken
+    public function getAccessToken(): AccessToken
     {
         $tokenId = sprintf('sf-%s', $this->options['username']);
 

--- a/src/Exceptions/BadRequest.php
+++ b/src/Exceptions/BadRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kapersoft\Sharefile\Exceptions;
+namespace Kapersoft\ShareFile\Exceptions;
 
 use Exception;
 use Psr\Http\Message\ResponseInterface;


### PR DESCRIPTION
This commit changes the ShareFile API to use the OAuth2 client library from The PHP League via a ShareFile Adapter.  This avoids a potentially unnecessary web request in the constructor and basically pushes all OAuth handling to a library that's dedicated to dealing with it.