### PR TITLE
Fix for composer autoloader; tweaks for running on PHP 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 vendor
 phpunit.xml
 .phpunit-watcher.yml
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ composer require kapersoft/sharefile-api
 ## Usage
 The first thing you need to do is get an OAuth2 key. Go to the [Get an API key](https://api.sharefile.com/rest/oauth2-request.aspx) section on the [ShareFile API site](https://api.sharefile.com/) to get this key.
 
-With an OAuth2 key you can instantiate a `Kapersoft\Sharefile\Client`:
+With an OAuth2 key you can instantiate a `Kapersoft\ShareFile\Client`:
 ```php
 $client = new Client('hostname', 'client_id', 'secret', 'username', 'password');
 ```
@@ -52,8 +52,8 @@ Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recen
 
 ## Testing
 In the `/tests`-folder are two tests defined:
-- `TestClient.php` tests the `Kapersoft\Sharefile\Client`-class using mock Guzzle objects;
-- `TestShareFileApi.php` tests the `Kapersoft\Sharefile\Client`-class using the live ShareFile API. To use this test fill in your ShareFile credentials under section `<PHP>` of the `phpunit.xml.dist`-file in the project root folder. Some tests need additional parameters to run. These parameters can be found in the first lines of the test.
+- `TestClient.php` tests the `Kapersoft\ShareFile\Client`-class using mock Guzzle objects;
+- `TestShareFileApi.php` tests the `Kapersoft\ShareFile\Client`-class using the live ShareFile API. To use this test fill in your ShareFile credentials under section `<PHP>` of the `phpunit.xml.dist`-file in the project root folder. Some tests need additional parameters to run. These parameters can be found in the first lines of the test.
  
 ## Security
 If you discover any security related issues, please email kapersoft@gmail.com instead of using the issue tracker.

--- a/composer.json
+++ b/composer.json
@@ -19,22 +19,22 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": ">=7.0",
         "guzzlehttp/guzzle": "^6.2"
     },
     "require-dev": {
         "larapack/dd": "1.*",
-        "mikey179/vfsStream": "^1.6",
-        "phpunit/phpunit": "6.4.x-dev"
+        "mikey179/vfsstream": "^1.6",
+        "phpunit/phpunit": ">=6.4"
     },
     "autoload": {
         "psr-4": {
-            "Kapersoft\\Sharefile\\": "src"
+            "Kapersoft\\ShareFile\\": "src"
         }
     },
     "autoload-dev": {
         "psr-4": {
-            "Kapersoft\\Sharefile\\Test\\": "tests"
+            "Kapersoft\\ShareFile\\Test\\": "tests"
         }
     },
     "scripts": {

--- a/src/Client.php
+++ b/src/Client.php
@@ -8,7 +8,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\ClientException;
-use Kapersoft\Sharefile\Exceptions\BadRequest;
+use Kapersoft\ShareFile\Exceptions\BadRequest;
 
 /**
  * Class Client.

--- a/src/Exceptions/BadRequest.php
+++ b/src/Exceptions/BadRequest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Kapersoft\Sharefile\Exceptions;
+namespace Kapersoft\ShareFile\Exceptions;
 
 use Exception;
 use Psr\Http\Message\ResponseInterface;

--- a/tests/TestClient.php
+++ b/tests/TestClient.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Kapersoft\Sharefile\Test;
+namespace Kapersoft\ShareFile\Test;
 
 use GuzzleHttp\Middleware;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use org\bovigo\vfs\vfsStream;
-use Kapersoft\Sharefile\Client;
+use Kapersoft\ShareFile\Client;
 use PHPUnit\Framework\TestCase;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\Exception\ClientException;
@@ -44,7 +44,7 @@ class TestClient extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->vfsRoot = vfsStream::setup('home');
     }

--- a/tests/TestShareFileApi.php
+++ b/tests/TestShareFileApi.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Kapersoft\Sharefile\Test;
+namespace Kapersoft\ShareFile\Test;
 
 use org\bovigo\vfs\vfsStream;
-use Kapersoft\Sharefile\Client;
+use Kapersoft\ShareFile\Client;
 use PHPUnit\Framework\TestCase;
 use org\bovigo\vfs\vfsStreamFile;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ConnectException;
-use Kapersoft\Sharefile\Exceptions\BadRequest;
+use Kapersoft\ShareFile\Exceptions\BadRequest;
 
 /**
  * Class TestClient.
@@ -39,7 +39,7 @@ class TestShareFileApi extends TestCase
      *
      * @return void
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->vfsRoot = vfsStream::setup('home');
     }


### PR DESCRIPTION
Changes:
* Namespaces are all updated to `Kapersoft\ShareFile`; composer's autoloader is case-sensitive.
* Supports PHP 8.
* Updated test `setUp()` methods to match prototype.